### PR TITLE
Realtime photon logging + delayed simulation start

### DIFF
--- a/Assets/Scripts/Logging/LiveLogger.cs
+++ b/Assets/Scripts/Logging/LiveLogger.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 public class LiveLogger : IDisposable
 {
     UdpClient _socket;
-    BinaryWriter _writer;
+    public BinaryWriter _writer;
     MemoryStream _stream;
     byte[] _buffer;
     const int Port = 40131;
@@ -20,26 +20,25 @@ public class LiveLogger : IDisposable
         _writer = new BinaryWriter(_stream);
     }
 
-    public void Log(AICarSyncSystem aiCarSystem, PlayerSystem playerSystem)
+    public void Log()
     {
-        if (_writer == null)
-        {
-            return;
-        }
-        var cars = aiCarSystem.Cars;
-        _writer.Write(cars.Count);
-        foreach (var car in aiCarSystem.Cars)
-        {
-            _writer.Write(car.transform.position);
-        }
-        var pedestrians = playerSystem.Avatars;
-        _writer.Write(pedestrians.Count);
-        foreach (var pedestrian in pedestrians)
-        {
-            _writer.Write(pedestrian.transform.position);
-        }
         _socket.Send(_buffer, (int)_stream.Position);
         _stream.Position = 0;
+    }
+
+    public void FrameMetadata(
+        int localDriver,
+        int numPersistentDrivers,
+        int numPedestrians,
+        int numCarLights,
+        int numPedestrianLights
+        )
+    {
+        _writer.Write(localDriver);
+        _writer.Write(numPersistentDrivers);
+        _writer.Write(numPedestrians);
+        _writer.Write(numCarLights);
+        _writer.Write(numPedestrianLights);
     }
 
     public void Dispose() => _socket.Dispose();

--- a/Assets/Scripts/Logging/LiveLogger.cs
+++ b/Assets/Scripts/Logging/LiveLogger.cs
@@ -10,6 +10,12 @@ public class LiveLogger : IDisposable
     MemoryStream _stream;
     byte[] _buffer;
     const int Port = 40131;
+    
+    public enum LogPacketType
+    {
+        Begin = 1,
+        Frame = 2,
+    }
 
     public void Init()
     {
@@ -20,13 +26,13 @@ public class LiveLogger : IDisposable
         _writer = new BinaryWriter(_stream);
     }
 
-    public void Log()
+    public void Flush()
     {
         _socket.Send(_buffer, (int)_stream.Position);
         _stream.Position = 0;
     }
 
-    public void FrameMetadata(
+    public void BeginLog(
         int localDriver,
         int numPersistentDrivers,
         int numPedestrians,
@@ -34,6 +40,7 @@ public class LiveLogger : IDisposable
         int numPedestrianLights
         )
     {
+        _writer.Write((int)LogPacketType.Begin);
         _writer.Write(localDriver);
         _writer.Write(numPersistentDrivers);
         _writer.Write(numPedestrians);

--- a/Assets/Scripts/Logging/WorldLogging.cs
+++ b/Assets/Scripts/Logging/WorldLogging.cs
@@ -107,6 +107,8 @@ public class WorldLogger
         return string.Join("/", names);
     }
 
+    public float RealtimeLogInterval = 0;
+    float lastRealtimeLog = 0;
     public void LogFrame(float ping, float time)
     {
         var aiCars = _aiCarSystem.Cars;
@@ -115,9 +117,12 @@ public class WorldLogger
         LogFrame(ping, time, newAiCarsCount, _fileWriter);
         if (_liveLogger != null)
         {
-            _liveLogger._writer.Write((int)LiveLogger.LogPacketType.Frame);
-            LogFrame(ping, time, newAiCarsCount, _liveLogger._writer);
-            _liveLogger.Flush();
+            if (newAiCarsCount > 0 || (Time.realtimeSinceStartup - lastRealtimeLog > RealtimeLogInterval)) {
+                _liveLogger._writer.Write((int)LiveLogger.LogPacketType.Frame);
+                LogFrame(ping, time, newAiCarsCount, _liveLogger._writer);
+                _liveLogger.Flush();
+                lastRealtimeLog = Time.realtimeSinceStartup;
+            }
         }
 
         _lastFrameAICarCount = aiCars.Count;

--- a/Assets/Scripts/Logging/WorldLogging.cs
+++ b/Assets/Scripts/Logging/WorldLogging.cs
@@ -101,34 +101,37 @@ public class WorldLogger
 
     public void LogFrame(float ping, float time)
     {
-        LogFrame(ping, time, _fileWriter);
+        var aiCars = _aiCarSystem.Cars;
+        var newAiCarsCount = aiCars.Count - _lastFrameAICarCount;
+
+        LogFrame(ping, time, newAiCarsCount, _fileWriter);
         if (_liveLogger != null)
         {
             _liveLogger.FrameMetadata(
                 _driverBuffer.IndexOf(_playerSystem.LocalPlayer),
-                _driverBuffer.Count,
+                _playerSystem.Cars.Count + _playerSystem.Passengers.Count,
                 _playerSystem.Pedestrians.Count,
                 _lights != null ? _lights.CarLights.Length : 0,
                 _lights != null ? _lights.PedestrianLights.Length : 0
             );
-            LogFrame(ping, time, _liveLogger._writer);
+            LogFrame(ping, time, newAiCarsCount, _liveLogger._writer);
             _liveLogger.Log();
         }
+
+        _lastFrameAICarCount = aiCars.Count;
     }
 
     //main logging logic
     //adds a single entry to the logfile
-    private void LogFrame(float ping, float time, BinaryWriter writer)
+    private void LogFrame(float ping, float time, int newAiCarsCount, BinaryWriter writer)
     {
         if (!active)
         {
             return;
         }
-        var aiCars = _aiCarSystem.Cars;
-        while (aiCars.Count > _lastFrameAICarCount)
+        for (int i = 0; i < newAiCarsCount; i++)
         {
             writer.Write((int)LogFrameType.AICarSpawn);
-            _lastFrameAICarCount++;
         }
         writer.Write((int)LogFrameType.PositionsUpdate);
         writer.Write(time - _startTime);

--- a/Assets/Scripts/Logging/WorldLogging.cs
+++ b/Assets/Scripts/Logging/WorldLogging.cs
@@ -84,6 +84,14 @@ public class WorldLogger
         {
             _liveLogger = new LiveLogger();
             _liveLogger.Init();
+            _liveLogger.BeginLog(
+                _driverBuffer.IndexOf(_playerSystem.LocalPlayer),
+                _playerSystem.Cars.Count + _playerSystem.Passengers.Count,
+                _playerSystem.Pedestrians.Count,
+                _lights != null ? _lights.CarLights.Length : 0,
+                _lights != null ? _lights.PedestrianLights.Length : 0
+            );
+            _liveLogger.Flush();
         }
     }
 
@@ -107,15 +115,9 @@ public class WorldLogger
         LogFrame(ping, time, newAiCarsCount, _fileWriter);
         if (_liveLogger != null)
         {
-            _liveLogger.FrameMetadata(
-                _driverBuffer.IndexOf(_playerSystem.LocalPlayer),
-                _playerSystem.Cars.Count + _playerSystem.Passengers.Count,
-                _playerSystem.Pedestrians.Count,
-                _lights != null ? _lights.CarLights.Length : 0,
-                _lights != null ? _lights.PedestrianLights.Length : 0
-            );
+            _liveLogger._writer.Write((int)LiveLogger.LogPacketType.Frame);
             LogFrame(ping, time, newAiCarsCount, _liveLogger._writer);
-            _liveLogger.Log();
+            _liveLogger.Flush();
         }
 
         _lastFrameAICarCount = aiCars.Count;
@@ -152,8 +154,7 @@ public class WorldLogger
                 Assert.IsNotNull(rb);
                 Assert.IsFalse(rb.isKinematic);
                 writer.Write(rb.velocity);
-            } else
-            if (_aiCarSystem.Cars.Contains(driver))
+            } else if (_aiCarSystem.Cars.Contains(driver))
             {
                 var rb = driver.GetComponent<Rigidbody>();
                 Assert.IsNotNull(rb);

--- a/Assets/Scripts/Networking/Client.cs
+++ b/Assets/Scripts/Networking/Client.cs
@@ -73,6 +73,7 @@ public class Client : NetworkSystem
             _playerSys.ActivatePlayerAICar();
         }
         _currentState = NetState.InGame;
+        Time.timeScale = 1f;
         var roleName = experimentRoleDefinition.Name;
         _logger.BeginLog($"ClientLog-{roleName}-", _lvlManager.ActiveExperiment, lights, Time.realtimeSinceStartup, true);
         _fixedTimeLogger.BeginLog($"ClientFixedTimeLog-{roleName}-", _lvlManager.ActiveExperiment, lights, Time.fixedTime, false);
@@ -85,6 +86,7 @@ public class Client : NetworkSystem
         _lvlManager.LoadLevelWithLocalPlayer(msg.Experiment, _client.MyPlayerId, msg.Roles);
         _roles = msg.Roles;
         _transitionPhase = TransitionPhase.LoadingLevel;
+        Time.timeScale = 0;
     }
     //handles player position updates
     void OnUpdatePoses(ISynchronizer sync, int _)

--- a/Assets/Scripts/Networking/Host.cs
+++ b/Assets/Scripts/Networking/Host.cs
@@ -112,7 +112,6 @@ public class Host : NetworkSystem
                         _playerReadyStatus[Host.PlayerId] = true;
                         if (AllReady())
                         {
-                            //tu sa zmiany
                             _lights = GameObject.FindObjectOfType<TrafficLightsSystem>();
                             foreach (var carSpawner in _lvlManager.ActiveExperiment.CarSpawners)
                             {
@@ -133,6 +132,7 @@ public class Host : NetworkSystem
                             _host.BroadcastReliable(new AllReadyMsg());
                             _transitionPhase = TransitionPhase.None;
                             _currentState = NetState.InGame;
+                            Time.timeScale = 1f;
                             _logger.BeginLog($"HostLog-{roleName}-", _lvlManager.ActiveExperiment, _lights, Time.realtimeSinceStartup, true);
                             _fixedTimeLogger.BeginLog($"HostFixedTimeLog-{roleName}-", _lvlManager.ActiveExperiment, _lights, Time.fixedTime, false);
                         }
@@ -147,16 +147,10 @@ public class Host : NetworkSystem
         }
     }
 
+    bool startSimulation = false;
     bool AllReady()
     {
-        for (int i = 0; i < UNetConfig.MaxPlayers; i++)
-        {
-            if (!_playerReadyStatus[i] && _playerRoles[i] != -1)
-            {
-                return false;
-            }
-        }
-        return true;
+        return startSimulation;
     }
 
     void ForEachConnectedPlayer(Action<int, Host> action)
@@ -202,7 +196,7 @@ public class Host : NetworkSystem
 
     bool started;
     //initializes experiment - sets it up locally and broadcasts experiment configuration message
-    void StartGame()
+    void PrepareSimulatiion()
     {
         if (started)
         {
@@ -211,6 +205,8 @@ public class Host : NetworkSystem
         {
             started = true;
         }
+        startSimulation = false;
+
         _msgDispatcher.ClearLevelMessageHandlers();
         _host.BroadcastReliable(new StartGameMsg
         {
@@ -230,8 +226,9 @@ public class Host : NetworkSystem
             _lvlManager.LoadLevelWithLocalPlayer(_selectedExperiment, 0, _playerRoles);
         }
         _transitionPhase = TransitionPhase.LoadingLevel;
+        Time.timeScale = 0;
     }
-    
+
     void UpdateGame()
     {
         if (Time.realtimeSinceStartup - _lastPoseUpdateSent > PoseUpdateInterval)
@@ -293,31 +290,50 @@ public class Host : NetworkSystem
         {
             case NetState.Lobby:
             {
-                if (_instantStartParams.SkipSelectionScreen)
-                {
-                    StartGame();
-                    PlayerRolesGUI();
-                    _playerSys.SelectMode(_instantStartParams.InputMode);
-                }
-                else
-                {
-                    //GUI.enabled = AllRolesSelected();
-                    if (GUILayout.Button("Start Game"))
+                    if (_transitionPhase == TransitionPhase.WaitingForAwakes)
                     {
-                        StartGame();
-                    }
-                    GUI.enabled = true;
-                    GUILayout.Label("Experiment:");
-                    for (int i = 0; i < _lvlManager.Experiments.Length; i++)
-                    {
-                        if (GUILayout.Button(_lvlManager.Experiments[i].Name + (i == _selectedExperiment ? " <--" : "")))
+                        string playerReadyStr = "Ready:\t";
+                        string playerRolesStr = "Role :\t";
+                        for (int i = 0; i < UNetConfig.MaxPlayers; i++)
                         {
-                            _selectedExperiment = i;
+                            playerReadyStr += (_playerReadyStatus[i]?"1":"0") + "\t";
+                            playerRolesStr += _playerRoles[i] + "\t";
+                        }
+                        GUILayout.Label(playerReadyStr);
+                        GUILayout.Label(playerRolesStr);
+                        if (GUILayout.Button("Start simulation"))
+                        {
+                            startSimulation = true;
                         }
                     }
-                    PlayerRolesGUI();
-                    _playerSys.SelectModeGUI();
-                }
+                    else
+                    {
+                        if (_instantStartParams.SkipSelectionScreen)
+                        {
+                            PrepareSimulatiion();
+                            PlayerRolesGUI();
+                            _playerSys.SelectMode(_instantStartParams.InputMode);
+                        }
+                        else
+                        {
+                            //GUI.enabled = AllRolesSelected();
+                            if (GUILayout.Button("Start Game"))
+                            {
+                                PrepareSimulatiion();
+                            }
+                            GUI.enabled = true;
+                            GUILayout.Label("Experiment:");
+                            for (int i = 0; i < _lvlManager.Experiments.Length; i++)
+                            {
+                                if (GUILayout.Button(_lvlManager.Experiments[i].Name + (i == _selectedExperiment ? " <--" : "")))
+                                {
+                                    _selectedExperiment = i;
+                                }
+                            }
+                            PlayerRolesGUI();
+                            _playerSys.SelectModeGUI();
+                        }
+                    }
                 break;
             }
             case NetState.InGame:

--- a/Assets/Scripts/Networking/Host.cs
+++ b/Assets/Scripts/Networking/Host.cs
@@ -112,6 +112,7 @@ public class Host : NetworkSystem
                         _playerReadyStatus[Host.PlayerId] = true;
                         if (AllReady())
                         {
+                            //tu sa zmiany
                             _lights = GameObject.FindObjectOfType<TrafficLightsSystem>();
                             foreach (var carSpawner in _lvlManager.ActiveExperiment.CarSpawners)
                             {
@@ -119,14 +120,19 @@ public class Host : NetworkSystem
                             }
                             _aiPedestrianSyncSystem = _lvlManager.ActiveExperiment.AIPedestrians;
                             _aiPedestrianSyncSystem.InitHost(_host);
-                            ExperimentRoleDefinition experimentRoleDefinition = _lvlManager.ActiveExperiment.Roles[_playerRoles[Host.PlayerId]];
-                            if (experimentRoleDefinition.AutonomousPath != null) {
-                                _playerSys.ActivatePlayerAICar();
+                            ExperimentRoleDefinition experimentRoleDefinition;
+                            var role = _playerRoles[Host.PlayerId];
+                            var roleName = "No role";
+                            if (role != -1) {
+                                experimentRoleDefinition = _lvlManager.ActiveExperiment.Roles[role];
+                                if (experimentRoleDefinition.AutonomousPath != null) {
+                                    _playerSys.ActivatePlayerAICar();
+                                }
+                                roleName = experimentRoleDefinition.Name;
                             }
                             _host.BroadcastReliable(new AllReadyMsg());
                             _transitionPhase = TransitionPhase.None;
                             _currentState = NetState.InGame;
-                            var roleName = experimentRoleDefinition.Name;
                             _logger.BeginLog($"HostLog-{roleName}-", _lvlManager.ActiveExperiment, _lights, Time.realtimeSinceStartup, true);
                             _fixedTimeLogger.BeginLog($"HostFixedTimeLog-{roleName}-", _lvlManager.ActiveExperiment, _lights, Time.fixedTime, false);
                         }
@@ -295,7 +301,7 @@ public class Host : NetworkSystem
                 }
                 else
                 {
-                    GUI.enabled = AllRolesSelected();
+                    //GUI.enabled = AllRolesSelected();
                     if (GUILayout.Button("Start Game"))
                     {
                         StartGame();

--- a/Assets/Scripts/Networking/LowLevel/SerializationHelpers.cs
+++ b/Assets/Scripts/Networking/LowLevel/SerializationHelpers.cs
@@ -124,20 +124,15 @@ public static class SerializationHelpers
 
     public static void Write(this BinaryWriter writer, Quaternion quaternion)
     {
-        writer.Write(quaternion.w);
-        writer.Write(quaternion.x);
-        writer.Write(quaternion.y);
-        writer.Write(quaternion.z);
+        var euler = quaternion.eulerAngles;
+        writer.Write(euler.x);
+        writer.Write(euler.y);
+        writer.Write(euler.z);
     }
 
     public static Quaternion ReadQuaternion(this BinaryReader reader)
     {
-        Quaternion q;
-        if (reader.BaseStream.Position == reader.BaseStream.Length)
-        {
-            Debug.Log("Test");
-        }
-        q.w = reader.ReadSingle();
+        Vector3 q;
         if (reader.BaseStream.Position == reader.BaseStream.Length)
         {
             Debug.Log("Test");
@@ -157,7 +152,7 @@ public static class SerializationHelpers
         {
             Debug.Log("Test");
         }
-        return q;
+        return Quaternion.Euler(q);
     }
 
     public static void Write(this BinaryWriter writer, List<int> ints)

--- a/Assets/Scripts/Networking/NetworkingManager.cs
+++ b/Assets/Scripts/Networking/NetworkingManager.cs
@@ -20,6 +20,7 @@ public class NetworkingManager : MonoBehaviour
     WorldLogger _logger;
     WorldLogger _fixedLogger;
     LogConverter _logConverter;
+    public float RealtimeLogInterval = 0.2f;
 
     [SerializeField]
     AICarSyncSystem _aiCarSystem;
@@ -31,6 +32,7 @@ public class NetworkingManager : MonoBehaviour
         _playerSystem = GetComponent<PlayerSystem>();
         _levelManager = new LevelManager(_playerSystem, Experiments);
         _logger = new WorldLogger(_playerSystem, _aiCarSystem);
+        _logger.RealtimeLogInterval = RealtimeLogInterval;
         _fixedLogger = new WorldLogger(_playerSystem, _aiCarSystem);
         _logConverter = new LogConverter(_playerSystem.PedestrianPrefab);
     }

--- a/README.md
+++ b/README.md
@@ -38,7 +38,46 @@ The coupled simulator supports a keyboard and a gaming steering wheel as input s
 The supported sources of output are a head-mounted display (HMD) and computer screen for the driver, a computer screen for the passenger, and a head-mounted display for the pedestrian. At the moment, supported HDM is Oculus Rift CV1.
 
 #### Networking and data logging
-The current number of human participants supported by the coupled simulator is three. However, this number can be expanded up to the number of agents supported by the network. Synchronisation in a local network is handled by a custom-made network manager designed to support the exchange of information between agents with low latency and real-time data logging at 50 Hz for variables from the Unity environment and up to 700Hz from the motion suit. The data that are logged include the three-dimensional position and rotation of the manual car and the AV, the use of blinkers by the driver of the manual car, and 150 position and angular variables from the motion suit. The data are stored in binary format, and the coupled simulator contains a function to convert the saved data into a CSV file. The host agent initiates a red bar that is displayed across all agents for 1 s to allow for visual synchronisation in case screen capture software is used.
+The current number of human participants supported by the coupled simulator is three. However, this number can be expanded up to the number of agents supported by the network. Synchronization in a local network is handled by a custom-made network manager designed to support the exchange of information between agents with low latency and real-time data logging at 50 Hz for variables from the Unity environment and up to 700Hz from the motion suit. The data that are logged include the three-dimensional position and rotation of the manual car and the AV, the use of blinkers by the driver of the manual car, and 150 position and angular variables from the motion suit. The data are stored in binary format, and the coupled simulator contains a function to convert the saved data into a CSV file. 
+Besides logging data to the binary file, the same set of frame data (in a very similar binary format) is being sent with requested intervals (that can be set with _NetworkingManger.RealtimeLogInterval_ property) during the simulation to UDP port 40131 on localhost. The data can be used to monitor the simulation with external tools at runtime. _Tools/log_receiver.py_ file contains an example python script that consumes binary data and assembles it into a structure that is easy to interact with.
+It should be started before starting the simulation with 'python3 log_receiver.py' from within the _Tools_ folder.
+The structure of the frame object (with example data) is as follows:
+```
+{
+   "timestamp":1.711700439453125,
+   "roundtrip":0.0,
+   "Driver [car index]":{ # single integer-indexed entry for a car avatar controlled pedestrian avatar
+      "position":(-94.58521270751953, -0.056745946407318115, 64.8435287475586),
+      "rotation":(0.5252280235290527, 90.8692626953125, 359.9905700683594),
+      "blinker":0,
+      "rigidbody":(3.1246094703674316, -0.0026992361526936293, -0.046936508268117905)
+   },
+   "Driver [car index]":{ # multiple integer-indexed entries for each AI-controller pedestrian avatar
+      "position":(-112.08060455322266, -0.056995689868927, 21.383098602294922),
+      "rotation":(0.5083497762680054, 157.48184204101562, -0.0032447741832584143),
+      "blinker":0,
+      "rigidbody":(0.5082536935806274, -0.0017757670721039176, -1.2219140529632568),
+      "speed":5.904001235961914,
+      "braking":false,
+      "stopped":false,
+      "takeoff":false,
+      "eyecontact":false
+   },
+   "Pedestrian [pedestrian index]":{ # multiple integer-indexed entries for each player or AI-controller pedestrian avatar
+       "bone  [bone index]":{ # multiple integer-indexed entries for each bone of pedestrian rig
+          "position":(-94.58521270751953, -0.056745946407318115, 64.8435287475586),
+          "rotation":(0.5252280235290527, 90.8692626953125, 359.9905700683594)
+       }
+   },
+   "CarLight [car traffic light index]":{ # multiple integer-indexed entries for each cars traffic light
+      "state":"b""\\x00"
+   },
+   "PedestrianLight [pedestrian traffic light index]":{ # multiple integer-indexed entries for each pedestrains traffic light
+      "state":"b""\\x02"
+   },
+}
+```
+The host agent may use _Visual syncing_ button to display a red bar across all clients and the host for 1 s to allow for visual synchronization in case screen capture software is used.
 
 ## Installation
 The simualator was tested on Windows 10 and macOS Mojave. All functionality is supported by both platforms. However, support for input and output devices was tested only on Windows 10.
@@ -54,9 +93,10 @@ To start the client press _Start Client_ button, enter the host IP address and p
 Steps to run an experiment:
 1. Start host and wait for clients to join if needed.
 2. Once all clients have joined, on the host, select one of the experiments listed under _Experiment:_.
-3. On the host, assign roles to participants.
+3. On the host, assign roles to participants. If no role is selected, the participant will run a "headless" mode.
 4. On both host and clients, each participant has to select control mode.
-5. Start an experiment with the _Start Game_ button.
+5. Start an experiment with the _Start Game_ button - all clients will load selected experiment.
+6. Once all connected clients are ready (the experiment scene is fully loaded), _Start simulation_ button on the host machine will start the simulation.
 
 # Instant start parametets
 If the user wants to prepare a build that runs simulation instantly with a selected experiment and role, he is able to do so by setting parameters of the InstantStartHostParameters struct. It can be accessed and changed on a _StartScene_ (scene) -> _Managers_ (game object) -> _NetworkingManager_ (component) -> _InstantStartParams_ (field). The struct consists of the following fields:

--- a/Tools/log_receiver.py
+++ b/Tools/log_receiver.py
@@ -7,141 +7,153 @@ HOST, PORT = "localhost", 40131
 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 sock.bind((HOST, PORT))
 
-numAICars = 0
-#int numAICars = 0;
-aiCarIndexes = []
-#List<int> aiCarIndexes = new List<int>();
-
 while True:
     received = sock.recv(1024)
     offset = 0
 
-#### this is almost one to one translation of relevant part of WorldLogging
-    LocalDriver = struct.unpack("i", received[offset:offset+4])[0]
+### this is almost one to one translation of relevant part of WorldLogging
+    packetType = struct.unpack("i", received[offset:offset+4])[0]
     offset = offset + 4
-    #log.LocalDriver = reader.ReadInt32();
-    numPersistentDrivers = struct.unpack("i", received[offset:offset+4])[0]
-    offset = offset + 4
-    #int numPersistentDrivers = reader.ReadInt32();    
-    numPedestrians = struct.unpack("i", received[offset:offset+4])[0]
-    offset = offset + 4
-    #int numPedestrians = reader.ReadInt32();    
-    numCarLights = struct.unpack("i", received[offset:offset+4])[0]
-    offset = offset + 4
-    #int numCarLights = reader.ReadInt32();    
-    numPedestrianLights = struct.unpack("i", received[offset:offset+4])[0]
-    offset = offset + 4
-    #int numPedestrianLights = reader.ReadInt32();
 
-
-    eventType = struct.unpack("i", received[offset:offset+4])[0]
-    offset = offset + 4
-    #var eventType = (LogFrameType)reader.ReadInt32();
-    while (eventType == 1) :
-    #if (eventType == LogFrameType.AICarSpawn)
-    #{
-        aiCarIndexes.append(numAICars + numPersistentDrivers)
-        #aiCarIndexes.Add(numAICars + numPersistentDrivers);
-        numAICars = numAICars + 1
-        #numAICars++;
-        #continue;
+    if (packetType == 1) : # Log Begin
+        numAICars = 0
+        #int numAICars = 0;
+        aiCarIndexes = []
+        #List<int> aiCarIndexes = new List<int>();
+        LocalDriver = struct.unpack("i", received[offset:offset+4])[0]
+        offset = offset + 4
+        #log.LocalDriver = reader.ReadInt32();
+        numPersistentDrivers = struct.unpack("i", received[offset:offset+4])[0]
+        offset = offset + 4
+        #int numPersistentDrivers = reader.ReadInt32();    
+        numPedestrians = struct.unpack("i", received[offset:offset+4])[0]
+        offset = offset + 4
+        #int numPedestrians = reader.ReadInt32();    
+        numCarLights = struct.unpack("i", received[offset:offset+4])[0]
+        offset = offset + 4
+        #int numCarLights = reader.ReadInt32();    
+        numPedestrianLights = struct.unpack("i", received[offset:offset+4])[0]
+        offset = offset + 4
+        #int numPedestrianLights = reader.ReadInt32();
+        print("begin")
+    elif (packetType == 2) : # Log Frame
         eventType = struct.unpack("i", received[offset:offset+4])[0]
         offset = offset + 4
-    #}
-    ###Assert.AreEqual(LogFrameType.PositionsUpdate, eventType);
-    frame = {}
-    #var frame = new SerializedFrame();
-    ###log.Frames.Add(frame);
-    frame["timestamp"] = struct.unpack("f", received[offset:offset+4])[0]
-    offset = offset + 4
-    #frame.Timestamp = reader.ReadSingle();
-    frame["roundtrip"] = struct.unpack("f", received[offset:offset+4])[0]
-    offset = offset + 4
-    #frame.RoundtripTime = reader.ReadSingle();
-
-    numDriversThisFrame = numAICars + numPersistentDrivers
-
-    #int numDriversThisFrame = numAICars + numPersistentDrivers;
-    for i in range(numDriversThisFrame):
-    #for (int i = 0; i < numDriversThisFrame; i++)
-    #{
-        key = "Driver " + str(i)
-        frame[key] = {}
-
-        frame[key]["position"] = struct.unpack("{}f".format(3), received[offset:offset+4*3])
-        offset = offset + 4*3  # 3 floats, 4 bytes each
-        #frame.DriverPositions.Add(reader.ReadVector3());
-        frame[key]["rotation"] = struct.unpack("{}f".format(3), received[offset:offset+4*3])
-        offset = offset + 4*3  # 3 floats, 4 bytes each
-        #frame.DriverRotations.Add(reader.ReadQuaternion());
-        frame[key]["blinker"] = struct.unpack("i", received[offset:offset+4])[0]
-        offset = offset + 4
-        #frame.BlinkerStates.Add((BlinkerState)reader.ReadInt32());
-        if (i == LocalDriver) :
-        #if (i == log.LocalDriver)
+        #var eventType = (LogFrameType)reader.ReadInt32();
+        while (eventType == 1) :
+        #if (eventType == LogFrameType.AICarSpawn)
         #{
-            frame[key]["rigidbody"] = struct.unpack("{}f".format(3), received[offset:offset+4*3]) # meters per second (not in Km per hour)
-            offset = offset + 4*3  # 3 floats, 4 bytes each
-            #frame.LocalDriverRbVelocity = reader.ReadVector3() * SpeedConvertion.Mps2Kmph;
-        elif (aiCarIndexes.count(i) > 0) :
-        #} else if (IsAICar(i))
-        #{
-            frame[key]["rigidbody"] = struct.unpack("{}f".format(3), received[offset:offset+4*3]) # meters per second (not in Km per hour)
-            offset = offset + 4*3  # 3 floats, 4 bytes each
-            #frame.AICarRbVelocities.Add(i, reader.ReadVector3() * SpeedConvertion.Mps2Kmph);
-            frame[key]["speed"] = struct.unpack("f", received[offset:offset+4])[0]
+            aiCarIndexes.append(numAICars + numPersistentDrivers)
+            #aiCarIndexes.Add(numAICars + numPersistentDrivers);
+            numAICars = numAICars + 1
+            #numAICars++;
+            #continue;
+            eventType = struct.unpack("i", received[offset:offset+4])[0]
             offset = offset + 4
-            #frame.AICarSpeeds.Add(i, reader.ReadSingle());
-            frame[key]["braking"] = struct.unpack("?", received[offset:offset+1])[0]
-            offset = offset + 1
-            #frame.braking.Add(i, reader.ReadBoolean());
-            frame[key]["stopped"] = struct.unpack("?", received[offset:offset+1])[0]
-            offset = offset + 1
-            #frame.stopped.Add(i, reader.ReadBoolean());
-            frame[key]["takeoff"] = struct.unpack("?", received[offset:offset+1])[0]
-            offset = offset + 1
-            #frame.takeoff.Add(i, reader.ReadBoolean());
-            frame[key]["eyecontact"] = struct.unpack("?", received[offset:offset+1])[0]
-            offset = offset + 1
-            #frame.eyecontact.Add(i, reader.ReadBoolean());
         #}
-    #}
-
-    for i in range(numPedestrians):
-    #for (int i = 0; i < numPedestrians; i++)
-    #{
-        key = "Pedestrian " + str(i)
-        frame[key] = {}
-
-        frame[key]["rosition"] = struct.unpack("{}f".format(3), received[offset:offset+4*3])
-        offset = offset + 4*3  # 3 floats, 4 bytes each
-        #frame.PedestrianPositions.Add(reader.ReadListVector3());
-        frame[key]["rotation"] = struct.unpack("{}f".format(3), received[offset:offset+4*3])
-        offset = offset + 4*3  # 3 floats, 4 bytes each
-        #frame.PedestrianRotations.Add(reader.ReadListQuaternion());
+        ###Assert.AreEqual(LogFrameType.PositionsUpdate, eventType);
+        frame = {}
+        #var frame = new SerializedFrame();
+        ###log.Frames.Add(frame);
+        frame["timestamp"] = struct.unpack("f", received[offset:offset+4])[0]
         offset = offset + 4
-        #_ = reader.ReadInt32(); // Blinkers, unused
-    #}
-    for i in range(numCarLights):
-    #for (int i = 0; i < numCarLights; i++)
-    #{
-        key = "CarLight " + str(i)
-        frame[key] = {}
+        #frame.Timestamp = reader.ReadSingle();
+        frame["roundtrip"] = struct.unpack("f", received[offset:offset+4])[0]
+        offset = offset + 4
+        #frame.RoundtripTime = reader.ReadSingle();
 
-        frame[key]["state"] = struct.unpack("c", received[offset:offset+1])[0]
-        offset = offset + 1
-        #frame.CarLightStates.Add((LightState)reader.ReadByte());
-    #}
-    for i in range(numPedestrianLights):
-    #for (int i = 0; i < numPedestrianLights; i++)
-    #{
-        key = "PedestrianLight " + str(i)
-        frame[key] = {}
+        numDriversThisFrame = numAICars + numPersistentDrivers
 
-        frame[key]["state"] = struct.unpack("c", received[offset:offset+1])[0]
-        offset = offset + 1
-        #frame.PedestrianLightStates.Add((LightState)reader.ReadByte());
-    #}
-#####
+        #int numDriversThisFrame = numAICars + numPersistentDrivers;
+        for i in range(numDriversThisFrame):
+        #for (int i = 0; i < numDriversThisFrame; i++)
+        #{
+            key = "Driver " + str(i)
+            frame[key] = {}
 
-    #print(frame)
+            frame[key]["position"] = struct.unpack("{}f".format(3), received[offset:offset+4*3])
+            offset = offset + 4*3  # 3 floats, 4 bytes each
+            #frame.DriverPositions.Add(reader.ReadVector3());
+            frame[key]["rotation"] = struct.unpack("{}f".format(3), received[offset:offset+4*3])
+            offset = offset + 4*3  # 3 floats, 4 bytes each
+            #frame.DriverRotations.Add(reader.ReadQuaternion());
+            frame[key]["blinker"] = struct.unpack("i", received[offset:offset+4])[0]
+            offset = offset + 4
+            #frame.BlinkerStates.Add((BlinkerState)reader.ReadInt32());
+            if (i == LocalDriver) :
+            #if (i == log.LocalDriver)
+            #{
+                frame[key]["rigidbody"] = struct.unpack("{}f".format(3), received[offset:offset+4*3]) # meters per second (not in Km per hour)
+                offset = offset + 4*3  # 3 floats, 4 bytes each
+                #frame.LocalDriverRbVelocity = reader.ReadVector3() * SpeedConvertion.Mps2Kmph;
+            elif (aiCarIndexes.count(i) > 0) :
+            #} else if (IsAICar(i))
+            #{
+                frame[key]["rigidbody"] = struct.unpack("{}f".format(3), received[offset:offset+4*3]) # meters per second (not in Km per hour)
+                offset = offset + 4*3  # 3 floats, 4 bytes each
+                #frame.AICarRbVelocities.Add(i, reader.ReadVector3() * SpeedConvertion.Mps2Kmph);
+                frame[key]["speed"] = struct.unpack("f", received[offset:offset+4])[0]
+                offset = offset + 4
+                #frame.AICarSpeeds.Add(i, reader.ReadSingle());
+                frame[key]["braking"] = struct.unpack("?", received[offset:offset+1])[0]
+                offset = offset + 1
+                #frame.braking.Add(i, reader.ReadBoolean());
+                frame[key]["stopped"] = struct.unpack("?", received[offset:offset+1])[0]
+                offset = offset + 1
+                #frame.stopped.Add(i, reader.ReadBoolean());
+                frame[key]["takeoff"] = struct.unpack("?", received[offset:offset+1])[0]
+                offset = offset + 1
+                #frame.takeoff.Add(i, reader.ReadBoolean());
+                frame[key]["eyecontact"] = struct.unpack("?", received[offset:offset+1])[0]
+                offset = offset + 1
+                #frame.eyecontact.Add(i, reader.ReadBoolean());
+            #}
+        #}
+
+        for i in range(numPedestrians):
+        #for (int i = 0; i < numPedestrians; i++)
+        #{
+            key = "Pedestrian " + str(i)
+            frame[key] = {}
+            num_bones = struct.unpack("i", received[offset:offset+4])[0]
+            offset = offset + 4
+            for j in range(num_bones):
+                bone_key = "bone " + str(j)
+                frame[key][bone_key] = {}
+                frame[key][bone_key]["position"] = struct.unpack("{}f".format(3), received[offset:offset+4*3])
+                offset = offset + 4*3  # 3 floats, 4 bytes each
+                #frame.PedestrianPositions.Add(reader.ReadListVector3());
+
+            num_bones = struct.unpack("i", received[offset:offset+4])[0]
+            offset = offset + 4
+            for j in range(num_bones):
+                bone_key = "bone " + str(j)
+                frame[key][bone_key]["rotation"] = struct.unpack("{}f".format(3), received[offset:offset+4*3])
+                offset = offset + 4*3  # 3 floats, 4 bytes each
+                #frame.PedestrianRotations.Add(reader.ReadListQuaternion());
+
+            offset = offset + 4
+            #_ = reader.ReadInt32(); // Blinkers, unused
+        #}
+        for i in range(numCarLights):
+        #for (int i = 0; i < numCarLights; i++)
+        #{
+            key = "CarLight " + str(i)
+            frame[key] = {}
+
+            frame[key]["state"] = struct.unpack("c", received[offset:offset+1])[0]
+            offset = offset + 1
+            #frame.CarLightStates.Add((LightState)reader.ReadByte());
+        #}
+        for i in range(numPedestrianLights):
+        #for (int i = 0; i < numPedestrianLights; i++)
+        #{
+            key = "PedestrianLight " + str(i)
+            frame[key] = {}
+
+            frame[key]["state"] = struct.unpack("c", received[offset:offset+1])[0]
+            offset = offset + 1
+            #frame.PedestrianLightStates.Add((LightState)reader.ReadByte());
+        #}
+###
+        print(frame)

--- a/Tools/log_receiver.py
+++ b/Tools/log_receiver.py
@@ -7,14 +7,14 @@ HOST, PORT = "localhost", 40131
 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 sock.bind((HOST, PORT))
 
+numAICars = 0
+#int numAICars = 0;
+aiCarIndexes = []
+#List<int> aiCarIndexes = new List<int>();
+
 while True:
     received = sock.recv(1024)
     offset = 0
-    
-    numAICars = 0
-    #int numAICars = 0;
-    aiCarIndexes = []
-    #List<int> aiCarIndexes = new List<int>();
 
 #### this is almost one to one translation of relevant part of WorldLogging
     LocalDriver = struct.unpack("i", received[offset:offset+4])[0]
@@ -71,7 +71,7 @@ while True:
         frame[key]["position"] = struct.unpack("{}f".format(3), received[offset:offset+4*3])
         offset = offset + 4*3  # 3 floats, 4 bytes each
         #frame.DriverPositions.Add(reader.ReadVector3());
-        frame[key]["rotation"] = struct.unpack("{}f".format(3), received[offset:offset+4*3]) #todo zmien na katy eulera
+        frame[key]["rotation"] = struct.unpack("{}f".format(3), received[offset:offset+4*3])
         offset = offset + 4*3  # 3 floats, 4 bytes each
         #frame.DriverRotations.Add(reader.ReadQuaternion());
         frame[key]["blinker"] = struct.unpack("i", received[offset:offset+4])[0]
@@ -80,13 +80,13 @@ while True:
         if (i == LocalDriver) :
         #if (i == log.LocalDriver)
         #{
-            frame[key]["rigidbody"] = struct.unpack("{}f".format(3), received[offset:offset+4*3]) #todo SpeedConvertion.Mps2Kmph
+            frame[key]["rigidbody"] = struct.unpack("{}f".format(3), received[offset:offset+4*3]) # meters per second (not in Km per hour)
             offset = offset + 4*3  # 3 floats, 4 bytes each
             #frame.LocalDriverRbVelocity = reader.ReadVector3() * SpeedConvertion.Mps2Kmph;
         elif (aiCarIndexes.count(i) > 0) :
         #} else if (IsAICar(i))
         #{
-            frame[key]["rigidbody"] = struct.unpack("{}f".format(3), received[offset:offset+4*3]) #todo SpeedConvertion.Mps2Kmph
+            frame[key]["rigidbody"] = struct.unpack("{}f".format(3), received[offset:offset+4*3]) # meters per second (not in Km per hour)
             offset = offset + 4*3  # 3 floats, 4 bytes each
             #frame.AICarRbVelocities.Add(i, reader.ReadVector3() * SpeedConvertion.Mps2Kmph);
             frame[key]["speed"] = struct.unpack("f", received[offset:offset+4])[0]
@@ -116,7 +116,7 @@ while True:
         frame[key]["rosition"] = struct.unpack("{}f".format(3), received[offset:offset+4*3])
         offset = offset + 4*3  # 3 floats, 4 bytes each
         #frame.PedestrianPositions.Add(reader.ReadListVector3());
-        frame[key]["rotation"] = struct.unpack("{}f".format(3), received[offset:offset+4*3]) #todo zmien na katy eulera
+        frame[key]["rotation"] = struct.unpack("{}f".format(3), received[offset:offset+4*3])
         offset = offset + 4*3  # 3 floats, 4 bytes each
         #frame.PedestrianRotations.Add(reader.ReadListQuaternion());
         offset = offset + 4
@@ -126,9 +126,9 @@ while True:
     #for (int i = 0; i < numCarLights; i++)
     #{
         key = "CarLight " + str(i)
-        frame[i] = {}
+        frame[key] = {}
 
-        frame[i]["state"] = struct.unpack("c", received[offset:offset+1])[0]
+        frame[key]["state"] = struct.unpack("c", received[offset:offset+1])[0]
         offset = offset + 1
         #frame.CarLightStates.Add((LightState)reader.ReadByte());
     #}
@@ -136,12 +136,12 @@ while True:
     #for (int i = 0; i < numPedestrianLights; i++)
     #{
         key = "PedestrianLight " + str(i)
-        frame[i] = {}
+        frame[key] = {}
 
-        frame[i]["state"] = struct.unpack("c", received[offset:offset+1])[0]
+        frame[key]["state"] = struct.unpack("c", received[offset:offset+1])[0]
         offset = offset + 1
         #frame.PedestrianLightStates.Add((LightState)reader.ReadByte());
     #}
 #####
 
-    print(frame)
+    #print(frame)

--- a/Tools/log_receiver.py
+++ b/Tools/log_receiver.py
@@ -10,21 +10,125 @@ sock.bind((HOST, PORT))
 while True:
     received = sock.recv(1024)
     offset = 0
-    num_cars = struct.unpack("i", received[0:4])[0]
+
+#### this is almost one to one translation of relevant part of WorldLogging
+    LocalDriver = struct.unpack("i", received[offset:offset+4])[0]
     offset = offset + 4
-
-    cars_pos = struct.unpack("{}f".format(num_cars*3),
-                             received[offset:offset+num_cars*4*3])
-    offset = offset + num_cars*4*3  # 3 floats, 4 bytes each
-
-    num_ped = struct.unpack("i", received[offset:offset+4])[0]
+    #log.LocalDriver = reader.ReadInt32();
+    numPersistentDrivers = struct.unpack("i", received[offset:offset+4])[0]
     offset = offset + 4
+    #int numPersistentDrivers = reader.ReadInt32();
+    numAICars = 0
+    #int numAICars = 0;
+    aiCarIndexes = []
+    #List<int> aiCarIndexes = new List<int>();
 
-    ped_pos = struct.unpack("{}f".format(num_ped*3),
-                            received[offset:offset+num_ped*4*3])
+    eventType = struct.unpack("i", received[offset:offset+4])[0]
+    offset = offset + 4
+    #var eventType = (LogFrameType)reader.ReadInt32();
+    if (eventType == 1) :
+    #if (eventType == LogFrameType.AICarSpawn)
+    #{
+        aiCarIndexes.append(numAICars + numPersistentDrivers)
+        #aiCarIndexes.Add(numAICars + numPersistentDrivers);
+        numAICars = numAICars + 1
+        #numAICars++;
+        continue
+        #continue;
+    #}
+    ###Assert.AreEqual(LogFrameType.PositionsUpdate, eventType);
+    frame = {}
+    #var frame = new SerializedFrame();
+    ###log.Frames.Add(frame);
+    frame["timestamp"] = struct.unpack("i", received[offset:offset+4])[0]
+    offset = offset + 4
+    #frame.Timestamp = reader.ReadSingle();
+    frame["roundtrip"] = struct.unpack("i", received[offset:offset+4])[0]
+    offset = offset + 4
+    #frame.RoundtripTime = reader.ReadSingle();
 
-    car_str = ", ".join(str(x) for x in cars_pos)
-    ped_str = ", ".join(str(x) for x in ped_pos)
+    numDriversThisFrame = numAICars + numPersistentDrivers
+    #int numDriversThisFrame = numAICars + numPersistentDrivers;
+    for i in range(numDriversThisFrame):
+    #for (int i = 0; i < numDriversThisFrame; i++)
+    #{
+        key = "Driver " + 1
+        frame[key] = {}
 
-    print("Received:\nCars:{} - {}\nPedestrians:{} - {}"
-          .format(num_cars, car_str, num_ped, ped_str))
+        frame[key]["position"] = struct.unpack("{}f".format(3), received[offset:offset+4*3])
+        offset = offset + 4*3  # 3 floats, 4 bytes each
+        #frame.DriverPositions.Add(reader.ReadVector3());
+        frame[key]["rotation"] = struct.unpack("{}f".format(3), received[offset:offset+4*3]) #todo zmien na katy eulera
+        offset = offset + 4*3  # 3 floats, 4 bytes each
+        #frame.DriverRotations.Add(reader.ReadQuaternion());
+        frame[key]["blinker"] = struct.unpack("i", received[offset:offset+4])[0]
+        offset = offset + 4
+        #frame.BlinkerStates.Add((BlinkerState)reader.ReadInt32());
+        if (i == LocalDriver) :
+        #if (i == log.LocalDriver)
+        #{
+            frame[key]["rigidbody"] = struct.unpack("{}f".format(3), received[offset:offset+4*3]) #todo SpeedConvertion.Mps2Kmph
+            offset = offset + 4*3  # 3 floats, 4 bytes each
+            #frame.LocalDriverRbVelocity = reader.ReadVector3() * SpeedConvertion.Mps2Kmph;
+        elif (aiCarIndexes.count(i) > 0) :
+        #} else if (IsAICar(i))
+        #{
+            frame[key]["rigidbody"] = struct.unpack("{}f".format(3), received[offset:offset+4*3]) #todo SpeedConvertion.Mps2Kmph
+            offset = offset + 4*3  # 3 floats, 4 bytes each
+            #frame.AICarRbVelocities.Add(i, reader.ReadVector3() * SpeedConvertion.Mps2Kmph);
+            frame[key]["speed"] = struct.unpack("i", received[offset:offset+4])[0]
+            offset = offset + 4
+            #frame.AICarSpeeds.Add(i, reader.ReadSingle());
+            frame[key]["braking"] = struct.unpack("i", received[offset:offset+1])[0]
+            offset = offset + 1
+            #frame.braking.Add(i, reader.ReadBoolean());
+            frame[key]["stopped"] = struct.unpack("i", received[offset:offset+1])[0]
+            offset = offset + 1
+            #frame.stopped.Add(i, reader.ReadBoolean());
+            frame[key]["takeoff"] = struct.unpack("i", received[offset:offset+1])[0]
+            offset = offset + 1
+            #frame.takeoff.Add(i, reader.ReadBoolean());
+            frame[key]["eyecontact"] = struct.unpack("i", received[offset:offset+1])[0]
+            offset = offset + 1
+            #frame.eyecontact.Add(i, reader.ReadBoolean());
+        #}
+    #}
+
+    for i in range(numPedestrians):
+    #for (int i = 0; i < numPedestrians; i++)
+    #{
+        key = "Pedestrian " + i
+        frame[key] = {}
+
+        frame[key]["rosition"] = struct.unpack("{}f".format(3), received[offset:offset+4*3])
+        offset = offset + 4*3  # 3 floats, 4 bytes each
+        #frame.PedestrianPositions.Add(reader.ReadListVector3());
+        frame[key]["rotation"] = struct.unpack("{}f".format(3), received[offset:offset+4*3]) #todo zmien na katy eulera
+        offset = offset + 4*3  # 3 floats, 4 bytes each
+        #frame.PedestrianRotations.Add(reader.ReadListQuaternion());
+        offset = offset + 4
+        #_ = reader.ReadInt32(); // Blinkers, unused
+    #}
+    for i in range(numCarLights):
+    #for (int i = 0; i < numCarLights; i++)
+    #{
+        key = "CarLight " + i
+        frame[i] = {}
+
+        frame[i]["state"] = struct.unpack("i", received[offset:offset+1])[0]
+        offset = offset + 1
+        #frame.CarLightStates.Add((LightState)reader.ReadByte());
+    #}
+    for i in range(numPedestrianLights):
+    #for (int i = 0; i < numPedestrianLights; i++)
+    #{
+        key = "PedestrianLight " + i
+        frame[i] = {}
+
+        frame[i]["state"] = struct.unpack("i", received[offset:offset+1])[0]
+        offset = offset + 1
+        #frame.PedestrianLightStates.Add((LightState)reader.ReadByte());
+    #}
+#####
+
+    print(frame)


### PR DESCRIPTION
This mostly concludes works on  issue # 11 - Experimenter control panel by:
- adding a possibility to run host without a role selected;
- exporting all of the logged data via UDP connection (with an example python script that parses and structures data);
- added one more host-controlled step to the experiment stating sequence - simulation no longer starts automatically when all players have loaded the scene, but await the signal from the host.